### PR TITLE
Implement GraphQL Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # aem-adaptor-micro-service
 An AEM adaptor to query, map and cache AEM responses
+
+## Required environment variables
+AEM_GRAPHQL_ENDPOINT = "AEM's GraphQL endpoint"
+APP_VERSION = "dts-aem-adaptor-ms/0.0.1"
+
+## GraphQL query example
+GraphQL queries are checked in under ./lib/graphql/queries/[project name]
+
+Initialize a GraphQLWrapper object providing the endpoint and user-agent header (example below).
+```
+from lib.graphql.client import GraphQLWrapper
+AEMClient = GraphQLWrapper(os.environ['AEM_GRAPHQL_ENDPOINT'], os.environ['APP_VERSION'])
+AEMClient.query("./lib/graphql/queries/sc-labs/home.graphql")
+```

--- a/lib/graphql/client.py
+++ b/lib/graphql/client.py
@@ -1,0 +1,21 @@
+from gql import Client, gql
+from gql.transport.requests import RequestsHTTPTransport
+
+class GraphQLWrapper:
+    def __init__(self, url, useragent):
+        transport = RequestsHTTPTransport(
+            url=url,
+            verify=True,
+            retries=3,
+            headers={'user-agent': useragent},
+        )
+        self.gqlclient = Client(transport=transport, fetch_schema_from_transport=True)
+
+    def load_query(self, path):
+        with open(path) as f:
+            return gql(f.read())
+
+    def query(self, path):
+        query = self.load_query(path)
+        result = self.gqlclient.execute(query)
+        print(result)

--- a/lib/graphql/queries/sc-labs/home.graphql
+++ b/lib/graphql/queries/sc-labs/home.graphql
@@ -1,0 +1,8 @@
+{
+	alphaDCHomeByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/dev/components/home/search-for-benefits-and-services") {
+	    item {
+            _path
+            scTitleEn
+        }
+	}
+}


### PR DESCRIPTION
## Description
GraphQL client wrapper implemented in project

## List of proposed changes
Added lib GraphQL client wrapper
Added example query file and sc-labs directory structure

## Additional notes
Add the following code to the application to query AEM
```
from lib.graphql.client import GraphQLWrapper
AEMClient = GraphQLWrapper(os.environ['AEM_GRAPHQL_ENDPOINT'], os.environ['APP_VERSION'])
AEMClient.query("./lib/graphql/queries/sc-labs/home.graphql")
```
AEM environment variables AEM_GRAPHQL_ENDPOINT and APP_VERSION will need to be configured
